### PR TITLE
[fix] Add Bun installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ attrib -r +a .husky/commit-msg
 echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
 ```
 
+### Bun
+
+```bash
+bun add byul
+echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
+# UNIX (macOS, Linux)
+chmod +x .husky/commit-msg
+# Windows (PowerShell)
+attrib -r +a .husky/commit-msg
+echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
+```
+
 ## 2. ✨ Features
 
 **byul** offers the following features:

--- a/README_KO.md
+++ b/README_KO.md
@@ -19,6 +19,7 @@ echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
 # UNIX (macOS, Linux)
 chmod +x .husky/commit-msg
 # Windows (PowerShell)
+attrib -r +a .husky/commit-msg
 echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
 ```
 
@@ -30,6 +31,7 @@ echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
 # UNIX (macOS, Linux)
 chmod +x .husky/commit-msg
 # Windows (PowerShell)
+attrib -r +a .husky/commit-msg
 echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
 ```
 
@@ -42,6 +44,7 @@ echo 'yarn node ./byul/dist/index.js "$1"' > .husky/commit-msg
 # UNIX (macOS, Linux)
 chmod +x .husky/commit-msg
 # Windows (PowerShell)
+attrib -r +a .husky/commit-msg
 echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
 ```
 
@@ -53,6 +56,19 @@ echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
 # UNIX (macOS, Linux)
 chmod +x .husky/commit-msg
 # Windows (PowerShell)
+attrib -r +a .husky/commit-msg
+echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
+```
+
+### Bun
+
+```bash
+bun add byul
+echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
+# UNIX (macOS, Linux)
+chmod +x .husky/commit-msg
+# Windows (PowerShell)
+attrib -r +a .husky/commit-msg
 echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
 ```
 


### PR DESCRIPTION
# 🚀 Pull Request Proposal

Add Bun installation instructions to README

## 📋 Work Details

### Bun

```bash
bun add byul
echo 'node ./node_modules/byul/dist/index.js "$1"' > .husky/commit-msg
# UNIX (macOS, Linux)
chmod +x .husky/commit-msg
# Windows (PowerShell)
attrib -r +a .husky/commit-msg
echo '{"byulFormat": "{type}: {commitMessage} #{issueNumber}"}' > byul.config.json
```
