### PR TITLE
[Fix] Fixed branch type formatting error, branch issue number extraction error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules
 
 # Ignore build output
 build
+
+# tmp
+.tmp

--- a/.tmp/test.js
+++ b/.tmp/test.js
@@ -1,0 +1,62 @@
+const ANSI_COLORS = {
+  yellow: "\x1b[33m",
+  reset: "\x1b[0m",
+};
+
+const mock_user_config = {
+  byulFormat: "{type}: {commitMessage} #{issueNumber}",
+};
+
+async function formatTitle(branchName, title) {
+  let branchType = "";
+  let issueNumber = "";
+
+  const parts = branchName.split("/");
+  branchType = parts[parts.length - 2] || parts[0];
+
+  const lastPart = parts[parts.length - 1];
+  const numberMatch = lastPart.match(/-(\d+)$/);
+  if (numberMatch) {
+    issueNumber = numberMatch[1];
+  }
+
+  if (!branchType) {
+    console.warn(
+      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`
+    );
+    return title;
+  }
+
+  const userConfig = mock_user_config;
+
+  let format =
+    userConfig?.byulFormat || "{type}: {commitMessage} #{issueNumber}";
+
+  format = format
+    .replace("{type}", branchType)
+    .replace("{issueNumber}", issueNumber)
+    .replace("{commitMessage}", title);
+
+  return format;
+}
+
+// 테스트
+const testCases = [
+  ["feature/login-123-234", "add app.tsx"],
+  ["react/dom/feat/login-23", "update login component"],
+  ["byul/feat/323login-23-2565", "refactor authentication"],
+  ["develop/323log4in-v23-2565-2345", "fix logger"],
+  ["develop/fix/323log4in/dadasd/df-v23-2565-2345", "fix logger"],
+];
+
+async function runTests() {
+  for (const [branchName, title] of testCases) {
+    console.log(`Branch: ${branchName}`);
+    console.log(`Title: ${title}`);
+    const result = await formatTitle(branchName, title);
+    console.log(`Result: ${result}`);
+    console.log("---");
+  }
+}
+
+runTests().catch((error) => console.error("Test error:", error));

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,13 +2,13 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 const ANSI_COLORS = {
-    cyan: '\x1b[36m',
-    gray: '\x1b[90m',
-    green: '\x1b[32m',
-    red: '\x1b[31m',
-    blue: '\x1b[34m',
-    yellow: '\x1b[33m',
-    reset: '\x1b[0m'
+    cyan: "\x1b[36m",
+    gray: "\x1b[90m",
+    green: "\x1b[32m",
+    red: "\x1b[31m",
+    blue: "\x1b[34m",
+    yellow: "\x1b[33m",
+    reset: "\x1b[0m",
 };
 async function formatCommitMessage() {
     const startTime = Date.now();
@@ -16,7 +16,9 @@ async function formatCommitMessage() {
     console.log(`${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`);
     console.log(`${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`);
     try {
-        const branchName = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+        const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+            .toString()
+            .trim();
         const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
         if (!commitMsgFile) {
             console.error(`${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`);
@@ -48,15 +50,17 @@ async function formatCommitMessage() {
     console.log();
 }
 async function formatTitle(branchName, title) {
-    const [branchType] = branchName.split("/");
-    const issueNumberMatch = branchName.match(/\d+/);
-    const issueNumber = issueNumberMatch ? issueNumberMatch[0] : "";
-    if (!branchName.includes("/")) {
-        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format (e.g., "type/issue"). Keeping the original commit message.${ANSI_COLORS.reset}`);
-        return title;
+    let branchType = "";
+    let issueNumber = "";
+    const parts = branchName.split("/");
+    branchType = parts[parts.length - 2] || parts[0];
+    const lastPart = parts[parts.length - 1];
+    const numberMatch = lastPart.match(/-(\d+)$/);
+    if (numberMatch) {
+        issueNumber = numberMatch[1];
     }
-    if (branchName.match(/\d+[.-]\d+/)) {
-        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ Invalid issue number format detected in branch name "${branchName}". Keeping the original commit message.${ANSI_COLORS.reset}`);
+    if (!branchType) {
+        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`);
         return title;
     }
     const userConfig = getUserConfig();

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,87 +2,120 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
 const ANSI_COLORS = {
-    cyan: "\x1b[36m",
-    gray: "\x1b[90m",
-    green: "\x1b[32m",
-    red: "\x1b[31m",
-    blue: "\x1b[34m",
-    yellow: "\x1b[33m",
-    reset: "\x1b[0m",
+  cyan: "\x1b[36m",
+  gray: "\x1b[90m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  blue: "\x1b[34m",
+  yellow: "\x1b[33m",
+  reset: "\x1b[0m",
 };
 async function formatCommitMessage() {
-    const startTime = Date.now();
-    console.log();
-    console.log(`${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`);
-    console.log(`${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`);
-    try {
-        const branchName = execSync("git rev-parse --abbrev-ref HEAD")
-            .toString()
-            .trim();
-        const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
-        if (!commitMsgFile) {
-            console.error(`${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`);
-            return;
-        }
-        console.log(`${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`);
-        const commitMessage = readFileSync(commitMsgFile, "utf8");
-        const lines = commitMessage
-            .split("\n")
-            .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
-        if (lines.length === 0) {
-            console.error(`${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`);
-            return;
-        }
-        const title = lines[0];
-        const body = lines.slice(1).join("\n");
-        const formattedTitle = await formatTitle(branchName, title);
-        const formattedMessage = [formattedTitle, body]
-            .filter(Boolean)
-            .join("\n\n");
-        writeFileSync(commitMsgFile, formattedMessage);
-        console.log(`${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`);
+  const startTime = Date.now();
+  console.log();
+  console.log(
+    `${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`
+  );
+  console.log(
+    `${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`
+  );
+  try {
+    const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+      .toString()
+      .trim();
+    const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
+    if (!commitMsgFile) {
+      console.error(
+        `${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`
+      );
+      return;
     }
-    catch (error) {
-        console.error(`${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`, error);
-        process.exit(1);
+    console.log(
+      `${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`
+    );
+    const commitMessage = readFileSync(commitMsgFile, "utf8");
+    const lines = commitMessage
+      .split("\n")
+      .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+    if (lines.length === 0) {
+      console.error(
+        `${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`
+      );
+      return;
     }
-    console.log(`${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${ANSI_COLORS.reset}`);
-    console.log();
+    const title = lines[0];
+    const body = lines.slice(1).join("\n");
+    const formattedTitle = await formatTitle(branchName, title);
+    const formattedMessage = [formattedTitle, body]
+      .filter(Boolean)
+      .join("\n\n");
+    writeFileSync(commitMsgFile, formattedMessage);
+    console.log(
+      `${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`
+    );
+  } catch (error) {
+    console.error(
+      `${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`,
+      error
+    );
+    process.exit(1);
+  }
+  console.log(
+    `${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${
+      ANSI_COLORS.reset
+    }`
+  );
+  console.log();
 }
 async function formatTitle(branchName, title) {
-    let branchType = "";
-    let issueNumber = "";
-    const parts = branchName.split("/");
-    branchType = parts[parts.length - 2] || parts[0];
-    const lastPart = parts[parts.length - 1];
-    const numberMatch = lastPart.match(/-(\d+)$/);
-    if (numberMatch) {
-        issueNumber = numberMatch[1];
-    }
-    if (!branchType) {
-        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`);
-        return title;
-    }
-    const userConfig = getUserConfig();
-    let format = (userConfig === null || userConfig === void 0 ? void 0 : userConfig.byulFormat) || "{type}: {commitMessage} #{issueNumber}";
-    format = format
-        .replace("{type}", branchType)
-        .replace("{issueNumber}", issueNumber)
-        .replace("{commitMessage}", title);
-    return format;
+  let branchType = "";
+  let issueNumber = "";
+  if (!branchName.includes("/")) {
+    console.warn(
+      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`
+    );
+    return title;
+  }
+  const parts = branchName.split("/");
+  branchType = parts[parts.length - 2] || parts[0];
+  const lastPart = parts[parts.length - 1];
+  const numberMatch = lastPart.match(/-(\d+)$/);
+  if (numberMatch) {
+    issueNumber = numberMatch[1];
+  }
+  if (branchName.match(/\d+[.-]\d+/)) {
+    console.warn(
+      `${ANSI_COLORS.yellow}[2/2] ⚠️ Invalid issue number format detected in branch name "${branchName}". Keeping the original commit message.${ANSI_COLORS.reset}`
+    );
+    return title;
+  }
+  const userConfig = getUserConfig();
+  let format =
+    (userConfig === null || userConfig === void 0
+      ? void 0
+      : userConfig.byulFormat) || "{type}: {commitMessage} #{issueNumber}";
+  format = format
+    .replace("{type}", branchType)
+    .replace("{issueNumber}", issueNumber)
+    .replace("{commitMessage}", title);
+  return format;
 }
 function getUserConfig() {
-    try {
-        const configPath = join(process.cwd(), "byul.config.json");
-        const configFile = readFileSync(configPath, "utf8");
-        return JSON.parse(configFile);
-    }
-    catch (error) {
-        console.warn("Warning: Could not read byul.config.json file. Using default format.");
-        return null;
-    }
+  try {
+    const configPath = join(process.cwd(), "byul.config.json");
+    const configFile = readFileSync(configPath, "utf8");
+    return JSON.parse(configFile);
+  } catch (error) {
+    console.warn(
+      "Warning: Could not read byul.config.json file. Using default format."
+    );
+    return null;
+  }
 }
 formatCommitMessage().catch((error) => {
-    console.error(`${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`, error);
-    process.exit(1);
+  console.error(
+    `${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`,
+    error
+  );
+  process.exit(1);
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "love1ace",
     "commit",
     "byul"
-
   ],
   "bugs": {
     "url": "https://github.com/byulhook/byul/issues"
@@ -29,8 +28,7 @@
     "LICENSE"
   ],
   "homepage": "https://github.com/byulhook/byul#readme",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.4.0",
     "typescript": "^5.5.4"

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,13 @@ async function formatTitle(branchName: string, title: string): Promise<string> {
   let branchType = "";
   let issueNumber = "";
 
+  if (!branchName.includes("/")) {
+    console.warn(
+      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`
+    );
+    return title;
+  }
+
   const parts = branchName.split("/");
   branchType = parts[parts.length - 2] || parts[0];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,29 @@ import { join } from "path";
 import { execSync } from "child_process";
 
 const ANSI_COLORS = {
-  cyan: '\x1b[36m',
-  gray: '\x1b[90m',
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  blue: '\x1b[34m',
-  yellow: '\x1b[33m',
-  reset: '\x1b[0m'
+  cyan: "\x1b[36m",
+  gray: "\x1b[90m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  blue: "\x1b[34m",
+  yellow: "\x1b[33m",
+  reset: "\x1b[0m",
 };
 
 async function formatCommitMessage(): Promise<void> {
   const startTime = Date.now();
   console.log();
-  console.log(`${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`);
-  console.log(`${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`);
+  console.log(
+    `${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`
+  );
+  console.log(
+    `${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`
+  );
 
   try {
-    const branchName = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+    const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+      .toString()
+      .trim();
 
     const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
     if (!commitMsgFile) {
@@ -29,7 +35,9 @@ async function formatCommitMessage(): Promise<void> {
       return;
     }
 
-    console.log(`${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`);
+    console.log(
+      `${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`
+    );
 
     const commitMessage = readFileSync(commitMsgFile, "utf8");
 
@@ -59,36 +67,43 @@ async function formatCommitMessage(): Promise<void> {
       `${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`
     );
   } catch (error) {
-    console.error(`${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`, error);
+    console.error(
+      `${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`,
+      error
+    );
     process.exit(1);
   }
 
   console.log(
-    `${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${ANSI_COLORS.reset}`
+    `${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${
+      ANSI_COLORS.reset
+    }`
   );
   console.log();
 }
 
 async function formatTitle(branchName: string, title: string): Promise<string> {
-  const [branchType] = branchName.split("/");
-  const issueNumberMatch = branchName.match(/\d+/);
-  const issueNumber = issueNumberMatch ? issueNumberMatch[0] : "";
+  let branchType = "";
+  let issueNumber = "";
 
-  if (!branchName.includes("/")) {
-    console.warn(
-      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format (e.g., "type/issue"). Keeping the original commit message.${ANSI_COLORS.reset}`
-    );
-    return title;
+  const parts = branchName.split("/");
+  branchType = parts[parts.length - 2] || parts[0];
+
+  const lastPart = parts[parts.length - 1];
+  const numberMatch = lastPart.match(/-(\d+)$/);
+  if (numberMatch) {
+    issueNumber = numberMatch[1];
   }
 
-  if (branchName.match(/\d+[.-]\d+/)) {
+  if (!branchType) {
     console.warn(
-      `${ANSI_COLORS.yellow}[2/2] ⚠️ Invalid issue number format detected in branch name "${branchName}". Keeping the original commit message.${ANSI_COLORS.reset}`
+      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`
     );
     return title;
   }
 
   const userConfig = getUserConfig();
+
   let format =
     userConfig?.byulFormat || "{type}: {commitMessage} #{issueNumber}";
 
@@ -114,6 +129,9 @@ function getUserConfig(): { byulFormat: string } | null {
 }
 
 formatCommitMessage().catch((error) => {
-  console.error(`${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`, error);
+  console.error(
+    `${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`,
+    error
+  );
   process.exit(1);
 });


### PR DESCRIPTION

# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

### 수정 내역
- dist/index.js와 src/index.ts에 있는 formatTitle 함수를 수정함.

### formatTitle 함수 설명
- formatTitle 함수는 브랜치명과 커밋 메시지의 맨 윗줄을 가져온 다음에 브랜치명과 이슈번호를 추출함.
- formatTitle 함수는 추출한 브랜치명과 이슈번호를 바탕으로 커밋 메시지를 수정한 다음 이를 문자열로 리턴함.

### formatTitle 함수가 가진 문제점과 해결방안.
- 기존 formatTitle 함수는 두가지 문제가 있었음. 
- /기호가 여러개 있는 브랜치명이 있으면 아래와 같이 맨 앞의 / 기호 뒤의 브랜치타입만 인식을 하는 문제가 있었음.
- 이슈 번호 외의 다른 숫자가 브랜치명에 있다면 이슈 번호외의 숫자들을 이슈번호로 인식하는 문제가 있었음.
- formatTitle의 정규식 코드를 수정해서 해결함.


### 1. 브랜치 타입 추출 규칙

- 슬래시(/)로 구분: 브랜치 이름이 슬래시(/)로 구분되어 있을 경우, 마지막 슬래시 이전의 부분이 브랜치 타입으로 추출함.
```
예: feature/login-123 → feature
예: react/dom/feat/login-23 → feat
```

### 2. 이슈 번호 추출 규칙

- 대시(-)로 구분: 브랜치 이름의 마지막 부분에서, 가장 마지막 대시(-) 뒤의 숫자가 이슈 번호로 추출됨.
```
예: feature/login-123 → 123
예: byul/feat/323login-23-2565 → 2565
```
- 이슈 번호는 브랜치 이름의 끝부분에서 추출되며, 중간에 위치한 숫자들은 이슈 번호로 간주되지 않음.

###  formatTitle 실행 결과 예시
```
Branch: feature/login-123
Title: add app.tsx
Result: feature: add app.tsx #123
---
Branch: react/dom/feat/login-23
Title: update login component
Result: feat: update login component #23
---
Branch: byul/feat/323login-23-2565
Title: refactor authentication
Result: feat: refactor authentication #2565
---
Branch: develop/fix/323log4in-v23-2565-2345
Title: fix logger
Result: fix: fix logger #2345
---
```

## 🔧 Changes Summary

- Fixed the formatTitle function
- Changed the way branchName is extracted from formatTitle 
- Changed the way issueNumber is extracted from formatTitle 
- Fixed an error when there are multiple /s in the branch name 
- Fixed an error when there are multiple numbers in the branch name


## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

If you have any additional information or special requests, please include them here.