### PR TITLE
[Setting] Setting up automatic PR labelling and automatic PR contacts with github actions

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,8 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to 'author' to add PR's author as assignee
+addAssignees: author
+
+skipKeywords:
+  - wip

--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,8 +1,11 @@
-# Set to true to add reviewers to pull requests
 addReviewers: true
-
-# Set to 'author' to add PR's author as assignee
 addAssignees: author
+
+reviewers:
+  - nakyeonko3
+  - love1ace
+
+numberOfReviewers: 2
 
 skipKeywords:
   - wip

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+feat:
+  - head-branch: ['^feat', 'feat']
+
+setting:
+ - head-branch: ['^setting', 'setting']
+
+design:
+  - head-branch: ['^design', 'design']
+
+fix:
+  - head-branch: ['^fix', 'fix']
+
+chore:
+  - head-branch: ['^chore', 'chore']
+
+hotfix:
+  - head-branch: ['^hotfix', 'hotfix']
+
+style:
+  - head-branch: ['^style', 'style']
+
+refactor:
+  - head-branch: ['^refactor', 'refactor']
+
+test:
+  - head-branch: ['^test', 'test']
+
+docs:
+  - head-branch: ['^docs', 'docs']
+
+rename:
+  - head-branch: ['^rename', 'rename']
+
+remove:
+  - head-branch: ['^remove', 'remove']
+
+release:
+  - head-branch: ['^release', 'release']
+
+init:
+  - head-branch: ['^init', 'init']

--- a/.github/workflows/issue-auto_assign.yml
+++ b/.github/workflows/issue-auto_assign.yml
@@ -1,0 +1,14 @@
+name: Auto Assign Issue Creator
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  assignAuthor:
+    name: Assign author to Issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Assign author to Issue
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/pr-auto_assign.yaml
+++ b/.github/workflows/pr-auto_assign.yaml
@@ -1,0 +1,14 @@
+name: 'Auto Assign'
+on:
+  pull_request_target:
+    types: [opened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

- pr-auto_assign.ymal과 auto_ssign.yml을 통해 자동으로 pr 작성자가 pr
  담당자가 되도록 설정함.
- pr-labeler.yml과 labeler.yml를 통해 브랜치명에 따라서 자동으로 pr
  라벨링이 되도록 설정함.
- issue-auto_assign.yml를 통해 이슈 작성자가 이슈 담당자가 되도록함.
- 자동으로 nakyenoko3와 love1ace가 리뷰어로 지정되도록 수정함.

- pr-auto_assign.ymal and auto_ssign.yml to automatically make PR authors PR assignees; 
- pr-labeler.yml and labeler.yml to automatically label PRs based on branch name; 
- issue-auto_assign.yml to make issue authors issue assignees.
-  Fixed to automatically assign nakyenoko3 and love1ace as reviewers.


## 🔧 Changes Summary


## 📸 Screenshots (Optional)


## 📄 Additional Information
