### PR TITLE
[fix] BYUL 1.3.1 causes BYUL to work even when SQUASH or AMEND is present

### DIFF
--- a/byul.config.json
+++ b/byul.config.json
@@ -1,4 +1,3 @@
 {
   "byulFormat": "{type}: {commitMessage} (#{issueNumber})"
 }
-

--- a/byulhook.yml
+++ b/byulhook.yml
@@ -13,7 +13,7 @@
 #     lint:
 #       run: 'npm run lint'
 
-commit-msg:
-  commands:
-    byul:
-      run: "node dist/index.js .git/COMMIT_EDITMSG"
+# commit-msg:
+#   commands:
+#     byul:
+#       run: "node ./node_modules/byul/dist/index.js .git/COMMIT_EDITMSG"

--- a/dist/detectCommitMode.js
+++ b/dist/detectCommitMode.js
@@ -1,0 +1,32 @@
+import fs from "fs";
+const commitModes = {
+    message: (source, sha) => ({ mode: "message", isMessageProvided: true }),
+    merge: (source, sha) => ({ mode: "merge", isMessageProvided: true }),
+    squash: (source, sha) => ({ mode: "squash", isMessageProvided: true }),
+    commit: (source, sha) => ({
+        mode: sha ? "amend" : "normal",
+        isMessageProvided: false,
+    }),
+    template: (source, sha) => ({ mode: "template", isMessageProvided: false }),
+    default: (source, sha) => ({ mode: "normal", isMessageProvided: false }),
+};
+function detectCommitMode() {
+    const commitMsgFile = process.argv[2];
+    const commitSource = process.argv[3];
+    const commitSHA = process.argv[4];
+    if (!commitMsgFile) {
+        console.error("Error: Commit message file not provided.");
+        process.exit(1);
+    }
+    const modeHandler = commitModes[commitSource] || commitModes.default;
+    let { mode, isMessageProvided } = modeHandler(commitSource, commitSHA);
+    if (!isMessageProvided) {
+        const commitMsg = fs.readFileSync(commitMsgFile, "utf-8");
+        const nonCommentLines = commitMsg
+            .split("\n")
+            .filter((line) => !line.startsWith("#") && line.trim() !== "");
+        isMessageProvided = nonCommentLines.length > 0;
+    }
+    return { mode, isMessageProvided };
+}
+export { detectCommitMode };

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,7 +14,9 @@ const ANSI_COLORS = {
 async function formatCommitMessage() {
     const { mode } = detectCommitMode();
     if (mode === "squash" || mode === "amend") {
-        console.log(`${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...`);
+        console.log();
+        console.log(`${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...${ANSI_COLORS.reset}`);
+        console.log();
         return;
     }
     const startTime = Date.now();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,121 +1,98 @@
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
+import { detectCommitMode } from "./detectCommitMode.js";
 const ANSI_COLORS = {
-  cyan: "\x1b[36m",
-  gray: "\x1b[90m",
-  green: "\x1b[32m",
-  red: "\x1b[31m",
-  blue: "\x1b[34m",
-  yellow: "\x1b[33m",
-  reset: "\x1b[0m",
+    cyan: "\x1b[36m",
+    gray: "\x1b[90m",
+    green: "\x1b[32m",
+    red: "\x1b[31m",
+    blue: "\x1b[34m",
+    yellow: "\x1b[33m",
+    reset: "\x1b[0m",
 };
 async function formatCommitMessage() {
-  const startTime = Date.now();
-  console.log();
-  console.log(
-    `${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`
-  );
-  console.log(
-    `${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`
-  );
-  try {
-    const branchName = execSync("git rev-parse --abbrev-ref HEAD")
-      .toString()
-      .trim();
-    const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
-    if (!commitMsgFile) {
-      console.error(
-        `${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`
-      );
-      return;
+    const { mode } = detectCommitMode();
+    if (mode === "squash" || mode === "amend") {
+        console.log(`${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...`);
+        return;
     }
-    console.log(
-      `${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`
-    );
-    const commitMessage = readFileSync(commitMsgFile, "utf8");
-    const lines = commitMessage
-      .split("\n")
-      .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
-    if (lines.length === 0) {
-      console.error(
-        `${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`
-      );
-      return;
+    const startTime = Date.now();
+    console.log();
+    console.log(`${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`);
+    console.log(`${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`);
+    try {
+        const branchName = execSync("git rev-parse --abbrev-ref HEAD")
+            .toString()
+            .trim();
+        const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
+        if (!commitMsgFile) {
+            console.error(`${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`);
+            return;
+        }
+        console.log(`${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`);
+        const commitMessage = readFileSync(commitMsgFile, "utf8");
+        const lines = commitMessage
+            .split("\n")
+            .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+        if (lines.length === 0) {
+            console.error(`${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`);
+            return;
+        }
+        const title = lines[0];
+        const body = lines.slice(1).join("\n");
+        const formattedTitle = await formatTitle(branchName, title);
+        const formattedMessage = [formattedTitle, body]
+            .filter(Boolean)
+            .join("\n\n");
+        writeFileSync(commitMsgFile, formattedMessage);
+        console.log(`${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`);
     }
-    const title = lines[0];
-    const body = lines.slice(1).join("\n");
-    const formattedTitle = await formatTitle(branchName, title);
-    const formattedMessage = [formattedTitle, body]
-      .filter(Boolean)
-      .join("\n\n");
-    writeFileSync(commitMsgFile, formattedMessage);
-    console.log(
-      `${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`
-    );
-  } catch (error) {
-    console.error(
-      `${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`,
-      error
-    );
-    process.exit(1);
-  }
-  console.log(
-    `${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${
-      ANSI_COLORS.reset
-    }`
-  );
-  console.log();
+    catch (error) {
+        console.error(`${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`, error);
+        process.exit(1);
+    }
+    console.log(`${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${ANSI_COLORS.reset}`);
+    console.log();
 }
 async function formatTitle(branchName, title) {
-  let branchType = "";
-  let issueNumber = "";
-  if (!branchName.includes("/")) {
-    console.warn(
-      `${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`
-    );
-    return title;
-  }
-  const parts = branchName.split("/");
-  branchType = parts[parts.length - 2] || parts[0];
-  const lastPart = parts[parts.length - 1];
-  const numberMatch = lastPart.match(/-(\d+)$/);
-  if (numberMatch) {
-    issueNumber = numberMatch[1];
-  }
-  if (branchName.match(/\d+[.-]\d+/)) {
-    console.warn(
-      `${ANSI_COLORS.yellow}[2/2] ⚠️ Invalid issue number format detected in branch name "${branchName}". Keeping the original commit message.${ANSI_COLORS.reset}`
-    );
-    return title;
-  }
-  const userConfig = getUserConfig();
-  let format =
-    (userConfig === null || userConfig === void 0
-      ? void 0
-      : userConfig.byulFormat) || "{type}: {commitMessage} #{issueNumber}";
-  format = format
-    .replace("{type}", branchType)
-    .replace("{issueNumber}", issueNumber)
-    .replace("{commitMessage}", title);
-  return format;
+    let branchType = "";
+    let issueNumber = "";
+    if (!branchName.includes("/")) {
+        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`);
+        return title;
+    }
+    const parts = branchName.split("/");
+    branchType = parts[parts.length - 2] || parts[0];
+    const lastPart = parts[parts.length - 1];
+    const numberMatch = lastPart.match(/-(\d+)$/);
+    if (numberMatch) {
+        issueNumber = numberMatch[1];
+    }
+    if (!branchType) {
+        console.warn(`${ANSI_COLORS.yellow}[2/2] ⚠️ The branch name "${branchName}" does not follow the required format. Keeping the original commit message.${ANSI_COLORS.reset}`);
+        return title;
+    }
+    const userConfig = getUserConfig();
+    let format = (userConfig === null || userConfig === void 0 ? void 0 : userConfig.byulFormat) || "{type}: {commitMessage} #{issueNumber}";
+    format = format
+        .replace("{type}", branchType)
+        .replace("{issueNumber}", issueNumber)
+        .replace("{commitMessage}", title);
+    return format;
 }
 function getUserConfig() {
-  try {
-    const configPath = join(process.cwd(), "byul.config.json");
-    const configFile = readFileSync(configPath, "utf8");
-    return JSON.parse(configFile);
-  } catch (error) {
-    console.warn(
-      "Warning: Could not read byul.config.json file. Using default format."
-    );
-    return null;
-  }
+    try {
+        const configPath = join(process.cwd(), "byul.config.json");
+        const configFile = readFileSync(configPath, "utf8");
+        return JSON.parse(configFile);
+    }
+    catch (error) {
+        console.warn("Warning: Could not read byul.config.json file. Using default format.");
+        return null;
+    }
 }
 formatCommitMessage().catch((error) => {
-  console.error(
-    `${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`,
-    error
-  );
-  process.exit(1);
+    console.error(`${ANSI_COLORS.red}Unhandled promise rejection:${ANSI_COLORS.reset}`, error);
+    process.exit(1);
 });

--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -10,104 +10,82 @@ function findGitOrHuskyDir(startDir) {
   let currentDir = startDir;
 
   while (currentDir !== path.parse(currentDir).root) {
-    if (existsSync(path.join(currentDir, ".git")) || existsSync(path.join(currentDir, ".husky")) || existsSync(path.join(currentDir, "lefthook.yml")) || existsSync(path.join(currentDir, "byulhook.yml"))) {
+    if (existsSync(path.join(currentDir, ".git"))) {
       return currentDir;
     }
     currentDir = path.dirname(currentDir);
   }
+  return null;
 }
 
 const rootDir = findGitOrHuskyDir(__dirname);
+if (!rootDir) {
+  console.error("Error: .git directory not found. Please run this script inside a Git repository.");
+  process.exit(1);
+}
 
 function writeConfigFile(filePath, defaultConfig) {
-  if (!existsSync(filePath)) {
-    writeFileSync(filePath, JSON.stringify(defaultConfig, null, 2), 'utf8');
-  } else {
-    const configFile = readFileSync(filePath, "utf8");
-    let config = configFile.trim() ? JSON.parse(configFile) : {};
+  try {
+    if (!existsSync(filePath)) {
+      writeFileSync(filePath, JSON.stringify(defaultConfig, null, 2), 'utf8');
+    } else {
+      const configFile = readFileSync(filePath, "utf8");
+      let config = configFile.trim() ? JSON.parse(configFile) : {};
 
-    if (!config.hasOwnProperty('byulFormat')) {
-      config.byulFormat = defaultConfig.byulFormat;
+      config = { ...defaultConfig, ...config };
       writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf8');
     }
+  } catch (error) {
+    console.error(`Failed to write config file at ${filePath}: ${error.message}`);
+    process.exit(1);
   }
 }
 
 function setupCommitMsgHook() {
-  const hookName = "commit-msg";
-  const gitHookFile = path.join(rootDir, ".git", "hooks", hookName);
-  const huskyHookFile = path.join(rootDir, ".husky", hookName);
-  const lefthookConfigFile = path.join(rootDir, "lefthook.yml");
-  const byulhookConfigFile = path.join(rootDir, "byulhook.yml");
+  const hookName = "prepare-commit-msg";
+  const gitHookDir = path.join(rootDir, ".git", "hooks");
+  const hookFile = path.join(gitHookDir, hookName);
 
-  const useHusky = existsSync(path.join(rootDir, ".husky"));
-  const useLefthook = existsSync(lefthookConfigFile);
-  const useByulhook = existsSync(byulhookConfigFile);
-
-  let hookFile;
-
-  if (useHusky) {
-    hookFile = huskyHookFile;
-    const byulHookScript = `
-# byulFormat
-node ./node_modules/byul/dist/index.js "$1"
-# byulFormat
-`;
-    writeFileSync(hookFile, byulHookScript, { mode: 0o755 });
-  } else if (useLefthook) {
-    hookFile = lefthookConfigFile;
-    const lefthookConfig = readFileSync(lefthookConfigFile, "utf8");
-    const lefthookScript = `
-commit-msg:
-  commands:
-    byul:
-      run: "node ./node_modules/byul/dist/index.js .git/COMMIT_EDITMSG"
-`;
-    if (!lefthookConfig.includes('node ./node_modules/byul/dist/index.js .git/COMMIT_EDITMSG')) {
-      writeFileSync(lefthookConfigFile, lefthookScript, { flag: 'a' });
+  try {
+    let existingHook = '';
+    if (existsSync(hookFile)) {
+      existingHook = readFileSync(hookFile, 'utf8');
     }
-  } else if (useByulhook) {
-    hookFile = byulhookConfigFile;
-    const byulhookConfig = readFileSync(byulhookConfigFile, "utf8");
-    const byulhookScript = `
-commit-msg:
-  commands:
-    byul:
-      run: "node ./node_modules/byul/dist/index.js .git/COMMIT_EDITMSG"
-`;
-    if (!byulhookConfig.includes('node ./node_modules/byul/dist/index.js .git/COMMIT_EDITMSG')) {
-      writeFileSync(byulhookConfigFile, byulhookScript, { flag: 'a' });
+
+    const byulCommand = `node ${path.join(rootDir, 'node_modules', 'byul', 'dist', 'index.js')} "$1" "$2" "$3"`;
+    let newHookContent = '#!/bin/sh\n\n';
+
+    if (existingHook && !existingHook.includes(byulCommand)) {
+      newHookContent += existingHook + '\n';
     }
-  } else {
-    hookFile = gitHookFile;
-    const byulHookScript = `
-# byulFormat
-COMMIT_MSG_FILE="$1"
-BRANCH_NAME=$(git symbolic-ref --short HEAD)
-node .node_modules/byul/dist/index.js "$COMMIT_MSG_FILE" "$BRANCH_NAME"
-# byulFormat
-`;
 
-    writeFileSync(hookFile, `#!/bin/sh\n\n${byulHookScript}\n`, { mode: 0o755 });
-  }
+    newHookContent += byulCommand + '\n';
 
+    writeFileSync(hookFile, newHookContent, { mode: 0o755 });
 
-  if (process.platform === "win32") {
-    execSync(`attrib -r +a "${hookFile}"`);
-  } else {
-    execSync(`chmod +x "${hookFile}"`);
+    if (process.platform !== "win32") {
+      execSync(`chmod +x "${hookFile}"`);
+    }
+  } catch (error) {
+    console.error(`Failed to set up the commit message hook: ${error.message}`);
+    process.exit(1);
   }
 }
 
 function setupByulConfig() {
-  const projectRoot = process.env.INIT_CWD || process.cwd();
-  const byulConfigPath = join(projectRoot, "byul.config.json");
+  try {
+    const projectRoot = process.env.INIT_CWD || process.cwd();
+    const byulConfigPath = join(projectRoot, "byul.config.json");
 
-  const defaultConfig = {
-    byulFormat: "{type}: {commitMessage} (#{issueNumber})",
-  };
+    const defaultConfig = {
+      byulFormat: "{type}: {commitMessage} (#{issueNumber})",
+    };
 
-  writeConfigFile(byulConfigPath, defaultConfig);
+    writeConfigFile(byulConfigPath, defaultConfig);
+  } catch (error) {
+    console.error(`Failed to set up byul configuration: ${error.message}`);
+    process.exit(1);
+  }
 }
 
 setupByulConfig();

--- a/src/detectCommitMode.ts
+++ b/src/detectCommitMode.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+
+type CommitMode =
+  | "message"
+  | "merge"
+  | "squash"
+  | "amend"
+  | "normal"
+  | "template";
+
+interface CommitInfo {
+  mode: CommitMode;
+  isMessageProvided: boolean;
+}
+
+type ModeHandler = (source: string, sha: string | undefined) => CommitInfo;
+
+const commitModes: Record<string, ModeHandler> = {
+  message: (source, sha) => ({ mode: "message", isMessageProvided: true }),
+  merge: (source, sha) => ({ mode: "merge", isMessageProvided: true }),
+  squash: (source, sha) => ({ mode: "squash", isMessageProvided: true }),
+  commit: (source, sha) => ({
+    mode: sha ? "amend" : "normal",
+    isMessageProvided: false,
+  }),
+  template: (source, sha) => ({ mode: "template", isMessageProvided: false }),
+  default: (source, sha) => ({ mode: "normal", isMessageProvided: false }),
+};
+
+function detectCommitMode(): CommitInfo {
+  const commitMsgFile = process.argv[2];
+  const commitSource = process.argv[3];
+  const commitSHA = process.argv[4];
+
+  if (!commitMsgFile) {
+    console.error("Error: Commit message file not provided.");
+    process.exit(1);
+  }
+
+  const modeHandler = commitModes[commitSource] || commitModes.default;
+  let { mode, isMessageProvided } = modeHandler(commitSource, commitSHA);
+
+  if (!isMessageProvided) {
+    const commitMsg = fs.readFileSync(commitMsgFile, "utf-8");
+    const nonCommentLines = commitMsg
+      .split("\n")
+      .filter((line) => !line.startsWith("#") && line.trim() !== "");
+
+    isMessageProvided = nonCommentLines.length > 0;
+  }
+
+  return { mode, isMessageProvided };
+}
+
+export { detectCommitMode, CommitInfo, CommitMode };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { execSync } from "child_process";
+import { detectCommitMode } from "./detectCommitMode.js";
 
 const ANSI_COLORS = {
   cyan: "\x1b[36m",
@@ -13,7 +14,16 @@ const ANSI_COLORS = {
 };
 
 async function formatCommitMessage(): Promise<void> {
+  const { mode } = detectCommitMode();
+
+  if (mode === "squash" || mode === "amend") {
+    console.log(
+      `${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...`
+    );
+    return;
+  }
   const startTime = Date.now();
+
   console.log();
   console.log(
     `${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,11 @@ async function formatCommitMessage(): Promise<void> {
   const { mode } = detectCommitMode();
 
   if (mode === "squash" || mode === "amend") {
+    console.log();
     console.log(
-      `${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...`
+      `${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND'...${ANSI_COLORS.reset}`
     );
+    console.log();
     return;
   }
   const startTime = Date.now();


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

- #53
- squash와 amend 동작일 때 byul이 동작하지 않게함
- detectCommitMode 함수를 이용해서 현재 커밋이 squash인지 amend인지 알아냄.
- 만약 amend나 squash일경우 byul의 동작을 막음.

- Prevent byul from working when squash and amend are in action 
- Use the detectCommitMode function to determine if the current commit is squash or amend 
- If it is amend or squash, prevent byul from working.


## 🔧 Changes Summary

Summarize the key changes made.

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

commit-msg훅 스크립트를 수정했습니다.
```bash
#!/bin/sh

node dist/index.js  "$1" "$2" "$3"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- 커밋 모드를 감지하는 기능 추가: 다양한 커밋 모드를 지원합니다(예: "message", "merge", "squash", "amend", "normal", "template").
	- 커밋 메시지 포맷팅 기능에 커밋 모드 감지 통합: 특정 모드("squash", "amend")에서 기능이 작동하지 않음을 알리는 메시지 로그 추가.
  
- **Bug Fixes**
	- 커밋 메시지 파일이 제공되지 않을 경우 오류 로그 추가.
  
- **Chores**
	- `byulhook.yml`에서 `commit-msg` 관련 명령어 비활성화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->