### PR TITLE
[fix] byul v1.4에서 git commit일 때 byul 포맷팅이 되지 않는 오류를 해결

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34,19 +34,24 @@ async function formatCommitMessage() {
         }
         console.log(`${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`);
         const commitMessage = readFileSync(commitMsgFile, "utf8");
-        const lines = commitMessage
-            .split("\n")
-            .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
-        if (lines.length === 0) {
+        const lines = commitMessage.split("\n");
+        let title = "";
+        let bodyStartIndex = 0;
+        if (lines.length === 0 && mode === "message") {
             console.error(`${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`);
             return;
         }
-        const title = lines[0];
-        const body = lines.slice(1).join("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].trim() !== "" && !lines[i].trim().startsWith("#")) {
+                title = lines[i];
+                bodyStartIndex = i + 1;
+            }
+        }
         const formattedTitle = await formatTitle(branchName, title);
-        const formattedMessage = [formattedTitle, body]
-            .filter(Boolean)
-            .join("\n\n");
+        const formattedMessage = [
+            formattedTitle,
+            ...lines.slice(bodyStartIndex),
+        ].join("\n");
         writeFileSync(commitMsgFile, formattedMessage);
         console.log(`${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,25 +53,30 @@ async function formatCommitMessage(): Promise<void> {
 
     const commitMessage = readFileSync(commitMsgFile, "utf8");
 
-    const lines = commitMessage
-      .split("\n")
-      .filter((line) => line.trim() !== "" && !line.trim().startsWith("#"));
+    const lines = commitMessage.split("\n");
+    let title = "";
+    let bodyStartIndex = 0;
 
-    if (lines.length === 0) {
+    if (lines.length === 0 && mode === "message") {
       console.error(
         `${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`
       );
       return;
     }
 
-    const title = lines[0];
-    const body = lines.slice(1).join("\n");
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].trim() !== "" && !lines[i].trim().startsWith("#")) {
+        title = lines[i];
+        bodyStartIndex = i + 1;
+      }
+    }
 
     const formattedTitle = await formatTitle(branchName, title);
 
-    const formattedMessage = [formattedTitle, body]
-      .filter(Boolean)
-      .join("\n\n");
+    const formattedMessage = [
+      formattedTitle,
+      ...lines.slice(bodyStartIndex),
+    ].join("\n");
 
     writeFileSync(commitMsgFile, formattedMessage);
 


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**



## 📋 Work Details

#57
1. git commit 일때 byul 커밋 포맷팅이 아예 안되는 버그가 발생함.
2. git commit을 할 때 이러한 메시지가 출력됨. Error: The commit message is empty after removing comments and empty lines 
3. 해결방안: formatCommitMessage 함수를 아래와 같이 수정.

![image](https://github.com/user-attachments/assets/63f596d8-e04f-4b76-af1c-e4172e132642)
```
async function formatCommitMessage() {
    const { mode } = detectCommitMode();
    if (mode === "squash" || mode === "amend" || mode === "merge") {
        console.log();
        console.log(`${ANSI_COLORS.red} byul does not work when 'SQUASH' or 'AMEND' or "MERGE"...${ANSI_COLORS.reset}`);
        console.log();
        return;
    }
    const startTime = Date.now();
    console.log();
    console.log(`${ANSI_COLORS.cyan}🔄 Starting byul - Developed by love1ace${ANSI_COLORS.reset}`);
    console.log(`${ANSI_COLORS.gray}[1/2] 🔍 Retrieving branch information...${ANSI_COLORS.reset}`);
    try {
        const branchName = execSync("git rev-parse --abbrev-ref HEAD")
            .toString()
            .trim();
        const commitMsgFile = process.env.HUSKY_GIT_PARAMS || process.argv[2];
        if (!commitMsgFile) {
            console.error(`${ANSI_COLORS.red}Error: No commit message file provided.${ANSI_COLORS.reset}`);
            return;
        }
        console.log(`${ANSI_COLORS.gray}[2/2] 📝 Formatting commit message...${ANSI_COLORS.reset}`);
        console.log("dasdasdasdasd");
        const commitMessage =  readFileSync(commitMsgFile, "utf8");

        let title ="";
        let bodyStartIndex = 0;
        const lines = commitMessage
            .split("\n")

  
        for(let i=0; i<lines.length;i++){
            if(lines[i].trim() !=="" && !lines[i].trim().startsWith("#")){
                title = lines[i];
                bodyStartIndex = i+1;
            }
        }
        if (lines.length === 0 && mode === "message") {
            console.error(`${ANSI_COLORS.red}Error: The commit message is empty after removing comments and empty lines.${ANSI_COLORS.reset}`);
            return;
        }
        const formattedTitle = await formatTitle(branchName, title);
        const formattedMessage = [formattedTitle, ...lines.slice(bodyStartIndex)]
            .join("\n");
        writeFileSync(commitMsgFile, formattedMessage);
        console.log(`${ANSI_COLORS.green}Success!${ANSI_COLORS.reset} byul has formatted the commit message.`);
    }
    catch (error) {
        console.error(`${ANSI_COLORS.red}Error formatting commit message:${ANSI_COLORS.reset}`, error);
        process.exit(1);
    }
    console.log(`${ANSI_COLORS.blue}✨ Done in ${(Date.now() - startTime) / 1000}s.${ANSI_COLORS.reset}`);
    console.log();
}
```

## 🔧 Changes Summary

Summarize the key changes made.

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

![image](https://github.com/user-attachments/assets/197d4a5f-c3fb-46ab-8b06-5cad3a20aa4f)


## 📄 Additional Information

If you have any additional information or special requests, please include them here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 커밋 메시지 처리 로직 개선으로 제목 및 본문 설정 방식 수정.
	- 빈 커밋 메시지에 대한 오류 처리 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->