### PR TITLE
fix: husky를 설치하고 byul설치 오류  (#68)

### DIFF
--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
-import { writeFileSync, existsSync, readFileSync } from 'fs';
-import path, { join } from 'path';
+import { writeFileSync, existsSync, readFileSync } from "fs";
+import path, { join } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -20,7 +20,9 @@ function findGitDir(startDir) {
 
 const rootDir = findGitDir(__dirname);
 if (!rootDir) {
-  console.error("Error: .git directory not found. Please run this script inside a Git repository.");
+  console.error(
+    "Error: .git directory not found. Please run this script inside a Git repository."
+  );
   process.exit(1);
 }
 
@@ -30,7 +32,7 @@ function getHooksPath(gitDir) {
     return path.join(gitDir, ".git", "hooks");
   }
 
-  const configContent = readFileSync(configPath, 'utf8');
+  const configContent = readFileSync(configPath, "utf8");
   const hooksPathMatch = configContent.match(/^\s*hooksPath\s*=\s*(.+)$/m);
 
   if (hooksPathMatch) {
@@ -48,12 +50,12 @@ const gitHookDir = getHooksPath(rootDir);
 
 function isHuskyInstalled() {
   try {
-    const packageJsonPath = path.join(rootDir, 'package.json');
+    const packageJsonPath = path.join(rootDir, "package.json");
     if (!existsSync(packageJsonPath)) return false;
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
     const deps = packageJson.dependencies || {};
     const devDeps = packageJson.devDependencies || {};
-    return 'husky' in deps || 'husky' in devDeps;
+    return "husky" in deps || "husky" in devDeps;
   } catch {
     return false;
   }
@@ -62,16 +64,18 @@ function isHuskyInstalled() {
 function writeConfigFile(filePath, defaultConfig) {
   try {
     if (!existsSync(filePath)) {
-      writeFileSync(filePath, JSON.stringify(defaultConfig, null, 2), 'utf8');
+      writeFileSync(filePath, JSON.stringify(defaultConfig, null, 2), "utf8");
     } else {
       const configFile = readFileSync(filePath, "utf8");
       let config = configFile.trim() ? JSON.parse(configFile) : {};
 
       config = { ...defaultConfig, ...config };
-      writeFileSync(filePath, JSON.stringify(config, null, 2), 'utf8');
+      writeFileSync(filePath, JSON.stringify(config, null, 2), "utf8");
     }
   } catch (error) {
-    console.error(`Failed to write config file at ${filePath}: ${error.message}`);
+    console.error(
+      `Failed to write config file at ${filePath}: ${error.message}`
+    );
     process.exit(1);
   }
 }
@@ -82,34 +86,36 @@ function setupCommitMsgHook() {
 
   try {
     if (isHuskyInstalled()) {
-      execSync(`npx husky add ${hookFile} 'node node_modules/byul/dist/index.js "$1" "$2" "$3"'`);
+      execSync(
+        `echo 'node node_modules/byul/dist/index.js "$1" "$2" "$3"' > ${hookFile}`
+      );
     } else {
-      let existingHook = '';
+      let existingHook = "";
       if (existsSync(hookFile)) {
-        existingHook = readFileSync(hookFile, 'utf8');
+        existingHook = readFileSync(hookFile, "utf8");
       }
 
-      const shebang = '#!/bin/sh';
+      const shebang = "#!/bin/sh";
       const byulHookCommand = `node node_modules/byul/dist/index.js "$1" "$2" "$3"`;
 
-      let newHookContent = '';
+      let newHookContent = "";
 
       if (existingHook) {
-        const lines = existingHook.split('\n');
+        const lines = existingHook.split("\n");
         const hasShebang = lines[0].startsWith(shebang);
         const hasByulCommand = existingHook.includes(byulHookCommand);
 
         if (!hasShebang) {
-          newHookContent += shebang + '\n';
+          newHookContent += shebang + "\n";
         } else {
-          newHookContent += lines[0] + '\n';
+          newHookContent += lines[0] + "\n";
         }
 
-        const hookBody = lines.slice(hasShebang ? 1 : 0).join('\n');
-        newHookContent += hookBody.trim() ? hookBody + '\n' : '';
+        const hookBody = lines.slice(hasShebang ? 1 : 0).join("\n");
+        newHookContent += hookBody.trim() ? hookBody + "\n" : "";
 
         if (!hasByulCommand) {
-          newHookContent += '\n' + byulHookCommand + '\n';
+          newHookContent += "\n" + byulHookCommand + "\n";
         }
       } else {
         newHookContent = `${shebang}\n\n${byulHookCommand}\n`;
@@ -132,25 +138,27 @@ function setupByulConfig() {
   const byulConfigPath = join(projectRoot, "byul.config.json");
 
   const defaultConfig = {
-    "byulFormat": "{type}: {commitMessage} (#{issueNumber})",
-    "AI": true,
-    "language": "English",
-    "model": "gpt-4o-mini",
-    "commitTypes": {
-      "feat": "Feature (new feature)",
-      "fix": "Bug fix (bug fix)",
-      "refactor": "Refactoring",
-      "style": "Code style (code formatting, whitespace, comments, semicolons: no changes to business logic)",
-      "docs": "Documentation (add, modify, delete docs, README)",
-      "test": "Tests (add, modify, delete test code: no changes to business logic)",
-      "settings": "Project settings",
-      "chore": "Miscellaneous changes like package manager mods, e.g., .gitignore",
-      "init": "Initial creation",
-      "rename": "Rename or move files/folders only",
-      "remove": "Delete files only",
-      "design": "UI/UX design changes like CSS",
-      "release": "Deployment or release, e.g., release/login-123"
-    }
+    byulFormat: "{type}: {commitMessage} (#{issueNumber})",
+    AI: true,
+    language: "English",
+    model: "gpt-4o-mini",
+    commitTypes: {
+      feat: "Feature (new feature)",
+      fix: "Bug fix (bug fix)",
+      refactor: "Refactoring",
+      style:
+        "Code style (code formatting, whitespace, comments, semicolons: no changes to business logic)",
+      docs: "Documentation (add, modify, delete docs, README)",
+      test: "Tests (add, modify, delete test code: no changes to business logic)",
+      settings: "Project settings",
+      chore:
+        "Miscellaneous changes like package manager mods, e.g., .gitignore",
+      init: "Initial creation",
+      rename: "Rename or move files/folders only",
+      remove: "Delete files only",
+      design: "UI/UX design changes like CSS",
+      release: "Deployment or release, e.g., release/login-123",
+    },
   };
 
   writeConfigFile(byulConfigPath, defaultConfig);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byul",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Write commit messages in 3 second",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
- setup.mjs에서 npx husky add를 이용해서 byul 스크립트를 설치할 때
  오류가 생김.
- npx husky add가 더이상 지원되지 않는 명령어라서 이런 에러가 발생
- setup.mjs에서 echo 'node node_modules/byul/dist/index.js "$1" "$2" "$3"' >
  ${hookFile} 로 수정함.
  
  
 ### 오류 내용
![image](https://github.com/user-attachments/assets/a07dd356-a990-40e8-8294-834c0fcf1fd1)


### setup.mjs 수정된 부분
![image](https://github.com/user-attachments/assets/90054326-0b7b-45aa-a80a-497041b73783)

  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버전 업데이트**
	- 패키지 버전이 2.0.3에서 2.0.4로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->