### PR TITLE
fix: dist/setup.mjs 수정  (#74)

### DIFF
--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -81,14 +81,27 @@ function writeConfigFile(filePath, defaultConfig) {
 }
 
 function readByulHookFile() {
-  const byulHookFile = path.join(
-    rootDir,
-    "node_modules",
-    "byul",
-    "dist",
-    "byul_script"
-  );
-  return readFileSync(byulHookFile, "utf8");
+  const possiblePaths = [
+    path.join(rootDir, "node_modules", "byul", "dist", "byul_script"),
+    path.join(
+      rootDir,
+      "..",
+      "..",
+      "node_modules",
+      "byul",
+      "dist",
+      "byul_script"
+    ),
+    path.join(rootDir, "byul", "dist", "byul_script"),
+  ];
+
+  for (const byulHookFile of possiblePaths) {
+    if (existsSync(byulHookFile)) {
+      return readFileSync(byulHookFile, "utf8");
+    }
+  }
+
+  throw new Error("Unable to find byul_script file.");
 }
 
 function setupCommitMsgHook() {


### PR DESCRIPTION
- dist/setup.mjs 안에서 실행 될 때 잘못된 경로를 읽는 문제를 해결함
- readByulHookFile 함수는 byul_script 파일을 찾아서 읽고, 읽은 값을
  string으로 바꿔서 리턴하는 함수임.
- readByulHookFile 함수가 읽는 파일경로는 다음과 같음
1. rootDir/node_modules/byul/dist/byul_script
2. rootDir/../../node_modules/byul/dist/byul_script
3. rootDir/dist/setup.mjs
