### PR TITLE
fix: setup.mjs 수정(#74)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,5 +14,9 @@ reviews:
       - "main"
       - "develop"
       - "release/*"
-chat:
+  path_filters:
+    include:
+      - "**/dist/**"
+    exclude:
+      - "**/node_modules/**"
   auto_reply: true

--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -83,18 +83,8 @@ function writeConfigFile(filePath, defaultConfig) {
 function readByulHookFile() {
   const possiblePaths = [
     path.join(rootDir, "node_modules", "byul", "dist", "byul_script"),
-    path.join(
-      rootDir,
-      "..",
-      "..",
-      "node_modules",
-      "byul",
-      "dist",
-      "byul_script"
-    ),
-    path.join(rootDir, "byul", "dist", "byul_script"),
+    path.join(rootDir, "dist", "byul_script"),
   ];
-
   for (const byulHookFile of possiblePaths) {
     if (existsSync(byulHookFile)) {
       return readFileSync(byulHookFile, "utf8");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "byul",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "byul",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "preinstall": "node dist/setup.mjs",
-    "prepare": "husky"
+    "preinstall": "node dist/setup.mjs"
   },
   "overrides": {
     "whatwg-url": "13.0.0"


### PR DESCRIPTION
-  readByulHookFile 함수가  '/home/badac/works/byul/node_modules/byul/dist/byul_script',
  '/home/badac/works/byul/dist/byul_script' 경로를 읽도록 수정함.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
  - `.coderabbit.yaml` 파일에 `path_filters` 추가
    - `include` 속성: `**/dist/**` 경로 포함
    - `exclude` 속성: `**/node_modules/**` 경로 제외
  - `package.json`에서 `prepare` 스크립트 제거
    - `husky` 준비 단계가 빌드 프로세스에서 삭제됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->