### PR TITLE
[hotfix] 2.0.6버전에서 husky 종속성이 있는 환경에서 byul이 설치 실패하는 오류 해결

### DIFF
--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -111,7 +111,7 @@ function setupCommitMsgHook() {
       const hasByulCommand = existingHuskyHook.includes(byulHookContent.trim());
 
       if (!hasByulCommand) {
-        execSync(`echo '${byulHookContent}' >> .husky/${hookName}`);
+        execSync(`echo '\n${byulHookContent}' >${rootDir}/.husky/${hookName}`);
       }
     } else {
       let existingHook = "";

--- a/dist/setup.mjs
+++ b/dist/setup.mjs
@@ -1,10 +1,21 @@
 import { execSync } from "child_process";
-import { writeFileSync, existsSync, readFileSync } from "fs";
+import { writeFileSync, existsSync, readFileSync, mkdirSync, chmodSync } from "fs";
 import path, { join } from "path";
 import { fileURLToPath } from "url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+const ANSI_COLORS = {
+    cyan: "\x1b[36m",
+    gray: "\x1b[90m",
+    green: "\x1b[32m",
+    red: "\x1b[31m",
+    blue: "\x1b[34m",
+    yellow: "\x1b[33m",
+    reset: "\x1b[0m",
+};
+
 
 function findGitDir(startDir) {
   let currentDir = startDir;
@@ -94,6 +105,32 @@ function readByulHookFile() {
   throw new Error("Unable to find byul_script file.");
 }
 
+
+function setupGitHook(hookName, byulHookContent) {
+  const rootDir = findGitDir(__dirname);
+  if (!rootDir) {
+    console.error("Git repository not found.");
+    return;
+  }
+
+  const hookPath = path.join(rootDir, '.husky', hookName);
+
+  try {
+    mkdirSync(path.join(rootDir, '.husky'), { recursive: true });
+
+    writeFileSync(hookPath, byulHookContent, 'utf8');
+
+    if (process.platform !== 'win32') {
+      chmodSync(hookPath, '755');
+    }
+
+    console.log(`${ANSI_COLORS.green}byul has been successfully set up for prepare-commit-msg!${ANSI_COLORS.reset}`);
+  } catch (error) {
+    console.error(`Error setting up Git hook: ${error.message}`);
+  }
+}
+
+
 function setupCommitMsgHook() {
   const hookName = "prepare-commit-msg";
   const hookFile = path.join(gitHookDir, hookName);
@@ -111,7 +148,7 @@ function setupCommitMsgHook() {
       const hasByulCommand = existingHuskyHook.includes(byulHookContent.trim());
 
       if (!hasByulCommand) {
-        execSync(`echo '\n${byulHookContent}' >${rootDir}/.husky/${hookName}`);
+        setupGitHook(hookName, byulHookContent);
       }
     } else {
       let existingHook = "";
@@ -147,6 +184,7 @@ function setupCommitMsgHook() {
       if (process.platform !== "win32") {
         execSync(`chmod +x "${hookFile}"`);
       }
+        console.log(`${ANSI_COLORS.green}byul has been successfully set up for prepare-commit-msg!${ANSI_COLORS.reset}`);
     }
   } catch (error) {
     console.error(`Failed to set up the commit message hook: ${error.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "byul",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Write commit messages in 3 second",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
# 🚀 Pull Request Proposal

**[Please briefly describe the work done]**

## 📋 Work Details

- #82
- root/.husky/prepare-commit-msg 위치에 byul스크립트가 생성되도록 수정함.
- [hotfix] 2.0.6버전에서 husky 종속성이 있는 환경에서 byul이 설치 실패하는 오류 해결
- window 11, husky 환경에서 byul 스크립트 설치 오류 해결
- husky가 설치는 되어있지만 .husky 폴더가 없을 경우 오류 해결

## 🔧 Changes Summary

Summarize the key changes made.

## 📸 Screenshots (Optional)

You can attach screenshots demonstrating the modified screens or features.

## 📄 Additional Information

If you have any additional information or special requests, please include them here.